### PR TITLE
add 'formatting' option for prettier json

### DIFF
--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -105,15 +105,23 @@ module Swagger
             resource = header.merge({:resource_path => "#{demod}", :apis => apis})
             camelize_keys_deep!(resource)
             # write controller resource file
-            File.open("#{api_file_path}/#{demod}.json", 'w') { |file| file.write(resource.to_json) }
+            write_to_file "#{api_file_path}/#{demod}.json", resource, config
             # append resource to resources array (for writing out at end)
             resources[:apis] << {path: "#{trim_leading_slash(debased_path)}.{format}", description: klass.swagger_config[:description]}
             results[:processed] << path
           end
           # write master resource file
           camelize_keys_deep!(resources)
-          File.open("#{api_file_path}/api-docs.json", 'w') { |file| file.write(resources.to_json) }
+
+          write_to_file "#{api_file_path}/api-docs.json", resources, config
           results
+        end
+        def write_to_file(path, structure, config={})
+          content = case config[:formatting]
+            when :pretty; JSON.pretty_generate structure
+            else;         structure.to_json
+          end
+          File.open(path, 'w') { |file| file.write content }
         end
       end
     end

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -126,6 +126,12 @@ describe Swagger::Docs::Generator do
         expect(results["1.0"][:processed].count).to eq 1
         expect(results["1.0"][:skipped].count).to eq 1
       end
+      it "writes pretty json files when set" do
+        config["1.0"][:formatting] = :pretty
+        generate(config)
+        resources = File.read FILE_RESOURCES
+        expect(resources.scan(/\n/).length).to be > 1
+      end
       context "resources files" do
         let(:resources) { File.read(FILE_RESOURCES)}
         let(:response) { JSON.parse(resources) }


### PR DESCRIPTION
Pretty self-explanatory.

FYI, I tested whether newlines exist in generated resources file. If you have a suggestion for a different mechanism for testing prettiness, I'd be happy to impl another way.
