### PR TITLE
Filter out path parameters if parameter is not in path

### DIFF
--- a/spec/fixtures/controllers/sample_controller.rb
+++ b/spec/fixtures/controllers/sample_controller.rb
@@ -8,6 +8,7 @@ module Api
       swagger_api :index do
         summary "Fetches all User items"
         param :query, :page, :integer, :optional, "Page number"
+        param :path, :nested_id, :integer, :optional, "Team Id"
         response :unauthorized
         response :not_acceptable, "The request you made is not acceptable"
         response :requested_range_not_satisfiable

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -23,6 +23,7 @@ describe Swagger::Docs::Generator do
   let(:routes) {[
     stub_route("^GET$", "index", "api/v1/ignored", "/api/v1/ignored(.:format)"),
     stub_route("^GET$", "index", "api/v1/sample", "/api/v1/sample(.:format)"),
+    stub_route("^GET$", "index", "api/v1/sample", "/api/v1/nested/:nested_id/sample(.:format)"),
     stub_route("^POST$", "create", "api/v1/sample", "/api/v1/sample(.:format)"),
     stub_route("^GET$", "show", "api/v1/sample", "/api/v1/sample/:id(.:format)"),
     stub_route("^PUT$", "update", "api/v1/sample", "/api/v1/sample/:id(.:format)"),
@@ -67,7 +68,7 @@ describe Swagger::Docs::Generator do
         expect(response["resourcePath"]).to eq "sample"
       end
       it "writes out expected api count" do
-        expect(response["apis"].count).to eq 5
+        expect(response["apis"].count).to eq 6
       end
       context "first api" do
         #"apis":[{"path":" /sample","operations":[{"summary":"Fetches all User items"
@@ -168,8 +169,7 @@ describe Swagger::Docs::Generator do
       context "resource file" do
         let(:resource) { FILE_RESOURCE.read }
         let(:response) { JSON.parse(resource) }
-        let(:first) { response["apis"].first }
-        let(:operations) { first["operations"] }
+        let(:operations) { api["operations"] }
         let(:params) { operations.first["parameters"] }
         let(:response_msgs) { operations.first["responseMessages"] }
         # {"apiVersion":"1.0","swaggerVersion":"1.2","basePath":"/api/v1","resourcePath":"/sample"
@@ -186,18 +186,20 @@ describe Swagger::Docs::Generator do
           expect(response["resourcePath"]).to eq "sample"
         end
         it "writes out expected api count" do
-          expect(response["apis"].count).to eq 5
+          expect(response["apis"].count).to eq 6
         end
         context "first api" do
+          let(:api) { response["apis"][0] }
+
           #"apis":[{"path":" /sample","operations":[{"summary":"Fetches all User items"
           #,"method":"get","nickname":"Api::V1::Sample#index"}]
           it "writes path correctly when api extension type is not set" do
-            expect(first["path"]).to eq "sample"
+            expect(api["path"]).to eq "sample"
           end
           it "writes path correctly when api extension type is set" do
             config[DEFAULT_VER][:api_extension_type] = :json
             generate(config)
-            expect(first["path"]).to eq "sample.json"
+            expect(api["path"]).to eq "sample.json"
           end
           it "writes summary correctly" do
             expect(operations.first["summary"]).to eq "Fetches all User items"
@@ -242,6 +244,15 @@ describe Swagger::Docs::Generator do
             end
             it "writes specified message correctly" do
               expect(response_msgs[1]["message"]).to eq "The request you made is not acceptable"
+            end
+          end
+        end
+
+        context "second api (nested)" do
+          let(:api) { response["apis"][1] }
+          context "parameters" do
+            it "has correct count" do
+              expect(params.count).to eq 2
             end
           end
         end


### PR DESCRIPTION
Example:

``` ruby
# config/routes.rb
resources :users

resources :teams do
  resources :users
end

# app/controllers/users_controller.rb
swagger_api :index do
  param :path, :team_id, :integer, :optional, 'List users only by this team'
end
def index
  @users = User.all
  @users = @users.where(team_id: params[:team_id]) if params[:team_id].present?
  respond_with(@users)
end
```

_swagger-docs_ currently generates the `team_id` parameter for both `/users` and `/team/:team_id/users`.  According to the [Swagger Documentation](https://github.com/wordnik/swagger-core/wiki/Parameters), a path parameter

>  must correspond to the associated path segment from the path field in the api object

This PR filters out path parameters when the parameter is not present in the API endpoint. In the example above, _swagger-docs_ would then only generate the `team_id` parameter for `/team/:team_id/users` 
