### PR TITLE
Status codes for response

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ class Api::V1::UsersController < ApplicationController
 end
 ```
 
+`response` takes a symbol or status code and passes it to `Rack::Utils.status_code`. The current list of status codes can be seen here: https://github.com/rack/rack/blob/master/lib/rack/utils.rb.
+
 ### Run rake task to generate docs
 
 ```


### PR DESCRIPTION
The codes available to pass to `response` are not documented in the README, so maybe link to where that info can be found.
