### PR TITLE
Fix so that ID params are not filtered out if an extension is specified

### DIFF
--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -110,7 +110,7 @@ module Swagger
               operations[:method] = verb
               operations[:nickname] = "#{path.camelize}##{action}"
               api_path = trim_slashes(get_api_path(trim_leading_slash(route.path.spec.to_s), config[:api_extension_type]).gsub("#{controller_base_path}",""))
-              operations[:parameters] = filter_path_params(api_path, operations[:parameters])
+              operations[:parameters] = filter_path_params(api_path, operations[:parameters], config[:api_extension_type])
               apis << {:path => api_path, :operations => [operations]}
             end
             demod = "#{debased_path.to_s.camelize}".demodulize.camelize.underscore
@@ -139,10 +139,10 @@ module Swagger
 
         private
 
-        def filter_path_params(path, params)
+        def filter_path_params(path, params, extension)
           params.reject do |param|
-            param_as_variable = "{#{param[:name]}}"
-            param[:param_type] == :path && !path.include?(param_as_variable)
+            param_as_regex = /\{#{Regexp.escape(param[:name])}(\.#{extension})?\}/
+            param[:param_type] == :path && !(path =~ param_as_regex)
           end
         end
       end

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -257,6 +257,20 @@ describe Swagger::Docs::Generator do
             end
           end
         end
+        context "with json set as extension type" do
+          before(:each) do
+            config[DEFAULT_VER][:api_extension_type] = :json
+            generate(config)
+          end
+          context "show api" do
+            let(:api) { response["apis"][3] }
+            context "parameters" do
+              it "has correct count" do
+                expect(params.count).to eq 1
+              end
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixed a bug where ID param path params were getting filtered out of the swagger docs because of confusion the path.

Eg.  the path would be /resources/{:id.json}
which wouldn't match:
{:id}
