### PR TITLE
Allow reopening of docs definition for the swagger_api DSL command

### DIFF
--- a/lib/swagger/docs/methods.rb
+++ b/lib/swagger/docs/methods.rb
@@ -27,9 +27,9 @@ module Swagger
 
         def swagger_api(action, &block)
           @swagger_dsl ||= {}
-          return if @swagger_dsl[action]
           dsl = SwaggerDSL.call(action, self, &block)
-          @swagger_dsl[action] = dsl
+          @swagger_dsl[action] ||= {}
+          @swagger_dsl[action].deep_merge!(dsl) { |key, old, new| Array(old) + Array(new) }
         end
 
         def swagger_model(model_name, &block)

--- a/spec/fixtures/controllers/sample_controller.rb
+++ b/spec/fixtures/controllers/sample_controller.rb
@@ -10,7 +10,13 @@ module Api
         param :query, :page, :integer, :optional, "Page number"
         param :path, :nested_id, :integer, :optional, "Team Id"
         response :unauthorized
+      end
+
+      swagger_api :index do
         response :not_acceptable, "The request you made is not acceptable"
+      end
+
+      swagger_api :index do
         response :requested_range_not_satisfiable
       end
 


### PR DESCRIPTION
This allows for some interesting inheritance mechanics, like defining the API
for a controller method in a superclass and then refining the API method, and
therefore documentation, in the subclass controller.
