### PR TITLE
Refactor write_docs to split the documentation generation from file writing

### DIFF
--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -298,7 +298,7 @@ describe Swagger::Docs::Generator do
                 }
               }
             }
-            expect(models['Tag']).to eq expected_model
+            expect(models['tag']).to eq expected_model
           end
         end
       end


### PR DESCRIPTION
Splitting the data generation from persistence allows it to be accessed without
having to read from the file system, like for example a special Rails controller
action that calls the generation method and outputs the JSON. Also, should make
it easier to maintain it.
