### PR TITLE
Fix development dependencies gems requirements

### DIFF
--- a/swagger-docs.gemspec
+++ b/swagger-docs.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.signing_key = File.expand_path("~/.gemcert/gem-private_key.pem") if $0 =~ /gem\z/
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake",  "~> 0"
-  spec.add_development_dependency "rspec",  "~> 3.0.0.beta2"
-  spec.add_development_dependency "rails",  "~> 0"
-  spec.add_development_dependency "appraisal",  "~> 0"
+  spec.add_development_dependency "rake", "~> 10"
+  spec.add_development_dependency "rspec", "= 3.0.0beta2"
+  spec.add_development_dependency "rails", ">= 3"
+  spec.add_development_dependency "appraisal", ">= 1"
 end


### PR DESCRIPTION
The previous development dependencies were strange, like requiring Rails and Rake versions `0.x.y`. Also, RSpec `3.0.0rc1` breaks the specs, so I fixed it to `3.0.0beta2`.

To test the error behavior, assuming you're running Bash and RVM, first remove all the installed gems with (some errors might show, but it's ok):
`for x in `gem list --no-versions`; do gem uninstall $x -a -x -I; done`
and then install the gems with bundler:
`bundle install`
then run the specs with `rake`, and the issue will appear.
