### PR TITLE
Made camelize model properties configurable and fixed swagger_model name capitalization issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ The following table shows all the current configuration options and their defaul
 <td>:pretty</td>
 </tr>
 
+<tr>
+<td><b>camelize_model_properties</b></td>
+<td>Camelizes property names of models. For example, a property name called first_name would be converted to firstName.</td>
+<td>true</td>
+</tr>
+
 </tbody>
 </table>
 
@@ -174,19 +180,19 @@ end
 ### DRYing up common documentation
 
 Suppose you have a header or a parameter that must be present on several controllers and methods. Instead of duplicating it on all the controllers you can do this on your API base controller:
- 
+
 ```ruby
 class Api::BaseController < ActionController::Base
   class << self
     Swagger::Docs::Generator::set_real_methods
- 
+
     def inherited(subclass)
       super
       subclass.class_eval do
         setup_basic_api_documentation
       end
     end
- 
+
     private
     def setup_basic_api_documentation
       [:index, :show, :create, :update, :delete].each do |api_action|
@@ -198,7 +204,7 @@ class Api::BaseController < ActionController::Base
   end
 end
 ```
- 
+
 And then use it as a superclass to all you API controllers. All the subclassed controllers will have the same documentation applied to them.
 
 ### DSL Methods

--- a/lib/swagger/docs.rb
+++ b/lib/swagger/docs.rb
@@ -1,5 +1,6 @@
 require "swagger/docs/config"
 require "swagger/docs/dsl"
+require "swagger/docs/api_declaration_file_metadata"
 require "swagger/docs/api_declaration_file"
 require "swagger/docs/generator"
 require "swagger/docs/impotent_methods"

--- a/lib/swagger/docs/api_declaration_file_metadata.rb
+++ b/lib/swagger/docs/api_declaration_file_metadata.rb
@@ -1,0 +1,18 @@
+module Swagger
+  module Docs
+    class ApiDeclarationFileMetadata
+      DEFAULT_SWAGGER_VERSION = "1.2"
+
+      attr_reader :api_version, :path, :base_path, :controller_base_path, :swagger_version, :camelize_model_properties
+
+      def initialize(api_version, path, base_path, controller_base_path, options={})
+        @api_version = api_version
+        @path = path
+        @base_path = base_path
+        @controller_base_path = controller_base_path
+        @swagger_version = options.fetch(:swagger_version, DEFAULT_SWAGGER_VERSION)
+        @camelize_model_properties = options.fetch(:camelize_model_properties, true)
+      end
+    end
+  end
+end

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -62,7 +62,7 @@ module Swagger
             ret = process_path(path, root, config, settings)
             results[ret[:action]] << ret
             if ret[:action] == :processed
-              resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root)
+              resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config)
               debased_path = get_debased_path(ret[:path], settings[:controller_base_path])
               resource_api = {
                 path: "#{Config.transform_path(trim_leading_slash(debased_path))}.{format}",
@@ -132,8 +132,12 @@ module Swagger
           {action: :processed, path: path, apis: apis, models: models, klass: klass}
         end
 
-        def generate_resource(path, apis, models, settings, root)
-          declaration = ApiDeclarationFile.new(path, apis, models, settings[:controller_base_path], root)
+        def generate_resource(path, apis, models, settings, root, config)
+          metadata = ApiDeclarationFileMetadata.new(root["apiVersion"], path, root["basePath"],
+                                                   settings[:controller_base_path],
+                                                   camelize_model_properties: config.fetch(:camelize_model_properties, true),
+                                                   swagger_version: root["swaggerVersion"])
+          declaration = ApiDeclarationFile.new(metadata, apis, models)
           declaration.generate_resource
         end
 

--- a/spec/lib/swagger/docs/api_declaration_file_metadata_spec.rb
+++ b/spec/lib/swagger/docs/api_declaration_file_metadata_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Swagger::Docs::ApiDeclarationFileMetadata do
+
+  describe "#initialize" do
+    it "sets the api_version property" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath")
+
+      expect(metadata.api_version).to eq("1.0")
+    end
+
+    it "sets the path property" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath")
+
+      expect(metadata.path).to eq("path")
+    end
+
+    it "sets the base_path property" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath")
+
+      expect(metadata.base_path).to eq("basePath")
+    end
+
+    it "sets the controller_base_path property" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath")
+
+      expect(metadata.controller_base_path).to eq("controllerBasePath")
+    end
+
+    it "defaults the swagger_version property to DEFAULT_SWAGGER_VERSION" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath")
+
+      expect(metadata.swagger_version).to eq(described_class::DEFAULT_SWAGGER_VERSION)
+    end
+
+    it "allows the swagger_version property to be_overriden" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath", swagger_version: "2.0")
+
+      expect(metadata.swagger_version).to eq("2.0")
+    end
+
+
+    it "defaults the camelize_model_properties property to true" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath")
+
+      expect(metadata.camelize_model_properties).to eq(true)
+    end
+
+    it "allows the camelize_model_properties property to be overidden" do
+      metadata = described_class.new("1.0", "path", "basePath", "controllerBasePath", camelize_model_properties: false)
+
+      expect(metadata.camelize_model_properties).to eq(false)
+    end
+  end
+end

--- a/spec/lib/swagger/docs/api_declaration_file_spec.rb
+++ b/spec/lib/swagger/docs/api_declaration_file_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe Swagger::Docs::ApiDeclarationFile do
-  let(:path) { "api/v1/sample" }
   let(:apis) do
     [
       {
@@ -47,21 +46,14 @@ describe Swagger::Docs::ApiDeclarationFile do
     }
   end
 
-  let(:controller_base_path) { "" }
-
-  let(:root) do
-    {
-      :api_version=>"1.0",
-      :swagger_version=>"1.2",
-      :base_path=>"http://api.no.where/",
-      :apis=>[]
-    }
+  let(:metadata) do
+    Swagger::Docs::ApiDeclarationFileMetadata.new("1.0", "api/v1/sample", "http://api.no.where/", "")
   end
 
   describe "#generate_resource" do
 
     it "generates the appropriate response" do
-      declaration = described_class.new(path, apis, models, controller_base_path, root)
+      declaration = described_class.new(metadata, apis, models)
 
       expected_response = {
         "apiVersion"=> declaration.api_version,
@@ -77,51 +69,104 @@ describe Swagger::Docs::ApiDeclarationFile do
   end
 
   describe "#base_path" do
-    it "returns root['basePath']" do
-      declaration = described_class.new(path, apis, models, controller_base_path, root)
-      expect(declaration.base_path).to eq(root['basePath'])
+    it "returns metadata.base_path" do
+      metadata = double("metadata", base_path: "/hello")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.base_path).to eq(metadata.base_path)
+    end
+  end
+
+  describe "#path" do
+    it "returns metadata.path" do
+      metadata = double("metadata", path: "/hello")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.path).to eq(metadata.path)
+    end
+  end
+
+  describe "#controller_base_path" do
+    it "returns metadata.controller_base_path" do
+      metadata = double("metadata", controller_base_path: "/hello")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.controller_base_path).to eq(metadata.controller_base_path)
     end
   end
 
   describe "#swagger_version" do
-    it "returns root['swaggerVersion']" do
-      declaration = described_class.new(path, apis, models, controller_base_path, root)
-      expect(declaration.swagger_version).to eq(root['swaggerVersion'])
+    it "returns metadata.swagger_version" do
+      metadata = double("metadata", swagger_version: "1.2")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.swagger_version).to eq(metadata.swagger_version)
     end
   end
 
   describe "#api_version" do
-    it "returns root['apiVersion']" do
-      declaration = described_class.new(path, apis, models, controller_base_path, root)
-      expect(declaration.swagger_version).to eq(root['apiVersion'])
+    it "returns metadata.api_version" do
+      metadata = double("metadata", api_version: "1.0")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.api_version).to eq(metadata.api_version)
+    end
+  end
+
+  describe "#camelize_model_properties" do
+    it "returns metadata.camelize_model_properties" do
+      metadata = double("metadata", camelize_model_properties: false)
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.camelize_model_properties).to eq(metadata.camelize_model_properties)
     end
   end
 
   describe "#models" do
-    it "returns a models hash that's ready for output" do
-      declaration = described_class.new(path, apis, models, controller_base_path, root)
-      expected_models_hash = {
-        "tag" =>
-        {
-          "id" => :Tag,
-          "required" =>[:id],
-          "properties" =>
+    context "with camelize_model_properties set to true" do
+      it "returns a models hash that's ready for output" do
+        declaration = described_class.new(metadata, apis, models)
+        allow(declaration).to receive(:camelize_model_properties).and_return(true)
+        expected_models_hash = {
+          "Tag" =>
           {
-            "id" =>{"type"=>:integer, "description"=>"User Id"},
-            "firstName"=>{"type"=>:string, "description"=>"First Name"},
-            "lastName"=>{"type"=>:string, "description"=>"Last Name"},
-          },
-          "description"=>"A Tag object."
+            "id" => :Tag,
+            "required" =>[:id],
+            "properties" =>
+            {
+              "id" =>{"type"=>:integer, "description"=>"User Id"},
+              "firstName"=>{"type"=>:string, "description"=>"First Name"},
+              "lastName"=>{"type"=>:string, "description"=>"Last Name"},
+            },
+            "description"=>"A Tag object."
+          }
         }
-      }
 
-      expect(declaration.models).to eq(expected_models_hash)
+        expect(declaration.models).to eq(expected_models_hash)
+      end
+    end
+
+    context "with camelize_model_properties set to false" do
+      it "returns a models hash that's ready for output" do
+        declaration = described_class.new(metadata, apis, models)
+        allow(declaration).to receive(:camelize_model_properties).and_return(false)
+        expected_models_hash = {
+          "Tag" =>
+          {
+            "id" => :Tag,
+            "required" =>[:id],
+            "properties" =>
+            {
+              "id" =>{"type"=>:integer, "description"=>"User Id"},
+              "first_name"=>{"type"=>:string, "description"=>"First Name"},
+              "last_name"=>{"type"=>:string, "description"=>"Last Name"},
+            },
+            "description"=>"A Tag object."
+          }
+        }
+
+        expect(declaration.models).to eq(expected_models_hash)
+      end
     end
   end
 
   describe "#apis" do
     it "returns a api hash that's ready for output" do
-      declaration = described_class.new(path, apis, models, controller_base_path, root)
+      declaration = described_class.new(metadata, apis, models)
       expected_apis_array = [
         {
           "path"=>"sample/{id}",

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -321,7 +321,7 @@ describe Swagger::Docs::Generator do
                 }
               }
             }
-            expect(models['tag']).to eq expected_model
+            expect(models['Tag']).to eq expected_model
           end
         end
       end


### PR DESCRIPTION
This addresses #49 by introducing a new configuration property `:camelize_model_properties`. The default  value is true to maintain backward compatibility. If set to false, it uses the model properties exactly the way they are passed in.

I also had an issue where if the model name was not camelcased, the model name in the parameter type field wouldn't match the key in the models hash.

``` json
{
  "apiVersion": "1.0",
  "swaggerVersion": "1.2",
  "basePath": "http://localhost:3000/",
  "apis": [
    {
      "path": "sk/start_purchase2",
      "operations": [
        {
          "summary": "...",
          "parameters": [
            {
              "paramType": "form",
              "name": "order_data",
              "type": "OrderData",
              "description": "Order Data",
              "required": true
            }
          ],
          "method": "post",
          "nickname": "Sk::V2::Purchases#start"
        }
      ]
    },
      ]
    }
  ],
  "resourcePath": "purchases",
  "models": {
    "orderData": {
      "id": "OrderData",
      "required": [ ... ],
      "properties": { ... }
    }
  }
}
```

You can see that the type of the "order_data" param ("OrderData") does not match up the it's key in the models hash ("orderData"). This was causing issues in the swagger ui because it couldn't find a model definition with a key of "OrderData".

Finally, to ease testability, I extracted a class called ApiDeclarationFile that is named after the Api declaration files in the swagger spec (https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#52-api-declaration). This class's responsibility is to build the resource hash that will be serialized as json and written out to a file. I made sure all of your test coverage passed and wrote my own coverage as it went.

Let me know if you have any feedback. I'm excited that I could fix these issues.
