### PR TITLE
Adding support for multiple engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,25 @@ class Swagger::Docs::Config
 end
 ```
 
+If you want swagger to find controllers in `Rails.application` and/or multiple
+engines you can override `base_application` to return an array. 
+
+```ruby
+class Swagger::Docs::Config
+  def self.base_application; [Rails.application, Api::Engine, SomeOther::Engine] end
+end
+```
+
+Or, if you prefer you can override `base_applications` for this purpose. The plural
+`base_applications` takes precedence over `base_application` and MUST return an
+array.
+
+```ruby
+class Swagger::Docs::Config
+  def self.base_applications; [Rails.application, Api::Engine, SomeOther::Engine] end
+end
+```
+
 #### Transforming the `path` variable
 
 Swagger allows a distinction between the API documentation server and the hosted API

--- a/lib/swagger/docs/config.rb
+++ b/lib/swagger/docs/config.rb
@@ -12,6 +12,10 @@ module Swagger
           @@base_api_controller = controller
         end
 
+        def base_applications
+          Array(base_application)
+        end
+
         def base_application
           Rails.application 
         end

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -124,7 +124,7 @@ module Swagger
           return {action: :skipped, path: path, reason: :klass_not_present} if !klass
           return {action: :skipped, path: path, reason: :not_swagger_resource} if !klass.methods.include?(:swagger_config) or !klass.swagger_config[:controller]
           apis, models = [], {}
-          Config.base_application.routes.routes.select{|i| i.defaults[:controller] == path}.each do |route|
+          routes.select{|i| i.defaults[:controller] == path}.each do |route|
             ret = get_route_path_apis(path, route, klass, settings, config)
             apis = apis + ret[:apis]
             models.merge!(ret[:models])
@@ -139,6 +139,10 @@ module Swagger
                                                    swagger_version: root["swaggerVersion"])
           declaration = ApiDeclarationFile.new(metadata, apis, models)
           declaration.generate_resource
+        end
+
+        def routes
+          Config.base_applications.map{|app| app.routes.routes.to_a }.flatten
         end
 
         def get_route_path_apis(path, route, klass, settings, config)
@@ -187,7 +191,7 @@ module Swagger
         end
 
         def get_route_paths(controller_base_path)
-          paths = Config.base_application.routes.routes.map{|i| "#{i.defaults[:controller]}" }
+          paths = routes.map{|i| "#{i.defaults[:controller]}" }
           paths.uniq.select{|i| i.start_with?(controller_base_path)}
         end
 

--- a/spec/lib/swagger/docs/config_spec.rb
+++ b/spec/lib/swagger/docs/config_spec.rb
@@ -28,4 +28,12 @@ describe Swagger::Docs::Config do
     end
   end
 
+  describe "::base_applications" do
+    before(:each) { allow( subject ).to receive(:base_application).and_return(:app) }
+    it "defaults to Rails.application an an Array" do
+      expect(subject.base_applications).to eq [:app]
+    end
+  end
+
+
  end


### PR DESCRIPTION
In order to support apps with swagger docs in the main app as well as one or more engines this patch allows the overriding of `Config.base_application` to optionally return an array. `Config.base_applications` is used to access these values to ensure we're always dealing with an array even when `base_application` only returns a single value
