### PR TITLE
Expose API version on transform_path for easier “No Server Integrations”

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ class method in your initializer:
 
 ```ruby
 class Swagger::Docs::Config
-  def self.transform_path(path)
-    "http://example.com/api-docs/#{path}"
+  def self.transform_path(path, api_version)
+    "http://example.com/api-docs/#{api_version}/#{path}"
   end
 end
 ```

--- a/lib/swagger/docs/config.rb
+++ b/lib/swagger/docs/config.rb
@@ -29,7 +29,7 @@ module Swagger
           @versions ||= {}
         end
         
-        def transform_path(path)
+        def transform_path(path, api_version)
           # This is only for overriding, so don't perform any path transformations by default.
           path
         end

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -68,7 +68,7 @@ module Swagger
               resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config)
               debased_path = get_debased_path(ret[:path], settings[:controller_base_path])
               resource_api = {
-                path: "#{Config.transform_path(trim_leading_slash(debased_path))}.{format}",
+                path: "#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}",
                 description: ret[:klass].swagger_config[:description]
               }
               root[:apis] << resource_api


### PR DESCRIPTION
Hello,

Thanks for this awesome gem. It was really easy to generate swagger JSON with this :)

This pull request aims on the following issue: it is interesting exposing the `api_version` variable on the `Swagger::Docs::Config.tranform_path` method.
# Why?
- I'm trying to generate multiple docs for more than one version of my API (v1, v2, v3, etc.)
- I'm following the 'No Server Integration' strategy
- The Swagger JSONs were stored on my public folder (`public/api-docs`)

I Tried to generate the docs, but each version overwrote `api-docs.json` generated by this gem. Example:

On the config I had:

``` ruby
class Swagger::Docs::Config
  def self.transform_path(path)
    "api-docs/#{path}"
  end
end

Swagger::Docs::Config.register_apis({
  "v0" => { ... },
  "v1" => { ... }
)}
```

After running the rake I got only one `api-docs.json`:

```
{
  "apiVersion": "v1",
  "swaggerVersion": "1.2",
  "basePath": "/",
  "apis": [
    ..
  ]
}
```

After that, I tried changing my `api_file_path` for each API version (v0 was `public/api-docs/v0` and v1 was `public/api-docs/v1`).

It generated successfully, but the `api-docs.json` for each version didn't reflect my public path folder.

EDIT: I've ran the specs with the command `appraisal rake spec` and all passed.
