### PR TITLE
Print errors when swagger fails to constantize a controller if SHOW_SWAG...

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ rake swagger:docs
 
 Swagger-ui JSON files should now be present in your api_file_path (e.g. ./public/api/v1)
 
+If a file is unexpectedly skipped, there may have been an error loading it, which swagger-docs swallows by default. To
+see the error messages run:
+```
+SHOW_SWAGGER_ERRORS=1 rake swagger:docs
+```
+
 ### Sample
 
 A sample Rails application where you can run the above rake command and view the output in swagger-ui can be found here:
@@ -310,7 +316,7 @@ end
 ```
 
 If you want swagger to find controllers in `Rails.application` and/or multiple
-engines you can override `base_application` to return an array. 
+engines you can override `base_application` to return an array.
 
 ```ruby
 class Swagger::Docs::Config

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -123,7 +123,11 @@ module Swagger
 
         def process_path(path, root, config, settings)
           return {action: :skipped, reason: :empty_path} if path.empty?
-          klass = "#{path.to_s.camelize}Controller".constantize rescue nil
+          begin
+            klass = "#{path.to_s.camelize}Controller".constantize
+          rescue => e
+            puts e if ENV['SHOW_SWAGGER_ERRORS']
+          end
           return {action: :skipped, path: path, reason: :klass_not_present} if !klass
           return {action: :skipped, path: path, reason: :not_swagger_resource} if !klass.methods.include?(:swagger_config) or !klass.swagger_config[:controller]
           apis, models, defined_nicknames = [], {}, []


### PR DESCRIPTION
By default errors when constantizing a controller are suppressed. When you run the rake task to generate docs and it does not work because of an error in my controller it would be useful to see the error.

Usually there are many errors I would not be interested in so they should not show by default.

The solution implemented here will only print the errors if a flag SHOW_SWAGGER_ERRORS is set.
