### PR TITLE
Added support for a :scoped parameter to indicate that controller URLs should be scoped

### DIFF
--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -204,7 +204,7 @@ module Swagger
         def get_settings(api_version, config)
           base_path = trim_trailing_slash(config[:base_path] || "")
           controller_base_path = trim_leading_slash(config[:controller_base_path] || "")
-          base_path += "/#{controller_base_path}" unless controller_base_path.empty?
+          base_path += "/#{controller_base_path}" unless controller_base_path.empty? || config[:scoped]
           api_file_path = config[:api_file_path]
           settings = {
             base_path: base_path,


### PR DESCRIPTION
The :scoped parameter makes it easy to specify that controllers should be scoped when generating docs. For my use case I specify API versions in my routes via an accept header such as application/vnd.example.v1+json along with a route constraint. As such, controllers live in app/controllers/v1, app/controllers/v2, etc, but all api endpoints are scoped to the root URL. Adding :scoped => true allows for per version documentation consistent with the underlying API routes.
