### PR TITLE
Documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ Suppose you have a header or a parameter that must be present on several control
 ```ruby
 class Api::BaseController < ActionController::Base
   class << self
-    Swagger::Docs::Generator::set_real_methods
 
     def inherited(subclass)
       super


### PR DESCRIPTION
Fixed a documentation error that resulted in Swagger::Docs::Generator::set_real_methods being called twice, causing controllers derived from a custom base class to be skipped during doc generation.