### PR TITLE
Added "exclude_api_version_in_path" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Swagger::Docs::Config.register_apis({
     :api_file_path => "public/api/v1/",
     # the URL base path to your API
     :base_path => "http://api.somedomain.com",
+    # if you don't pass API version in URL
+    # :exclude_api_version_in_path => true,
     # if you want to delete all .json files at each generation
     :clean_directory => false,
     # add custom attributes to api-docs
@@ -102,6 +104,12 @@ The following table shows all the current configuration options and their defaul
 <td><b>base_path</b></td>
 <td>The URI base path for your API - e.g. api.somedomain.com</td>
 <td>/</td>
+</tr>
+
+<tr>
+<td><b>exclude_api_version_in_path</b></td>
+<td>Set to true, if you don't have API version specified in url - e.g. /api/action, not /api/v1/action</td>
+<td>nil</td>
 </tr>
 
 <tr>
@@ -250,7 +258,7 @@ class Api::V1::UserController < Api::V1::BaseController
     response :not_acceptable
     response :unprocessable_entity
   end
-  
+
   swagger_api :update do |api|
     summary "Update an existing User item"
     Api::V1::UserController::add_common_params(api)
@@ -357,7 +365,7 @@ end
 ```
 
 If you want swagger to find controllers in `Rails.application` and/or multiple
-engines you can override `base_application` to return an array. 
+engines you can override `base_application` to return an array.
 
 ```ruby
 class Swagger::Docs::Config

--- a/lib/swagger/docs/config.rb
+++ b/lib/swagger/docs/config.rb
@@ -17,7 +17,7 @@ module Swagger
         end
 
         def base_application
-          Rails.application 
+          Rails.application
         end
 
         def register_apis(versions)
@@ -28,7 +28,7 @@ module Swagger
         def registered_apis
           @versions ||= {}
         end
-        
+
         def transform_path(path, api_version)
           # This is only for overriding, so don't perform any path transformations by default.
           path

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -129,7 +129,7 @@ module Swagger
           return {action: :skipped, path: path, reason: :not_swagger_resource} if !klass.methods.include?(:swagger_config) or !klass.swagger_config[:controller]
           apis, models, defined_nicknames = [], {}, []
           routes.select{|i| i.defaults[:controller] == path}.each do |route|
-            unless nickname_defined?(defined_nicknames, path, route) # only add once for each route once e.g. PATCH, PUT 
+            unless nickname_defined?(defined_nicknames, path, route) # only add once for each route once e.g. PATCH, PUT
               ret = get_route_path_apis(path, route, klass, settings, config)
               apis = apis + ret[:apis]
               models.merge!(ret[:models])
@@ -140,7 +140,7 @@ module Swagger
         end
 
         def route_verb(route)
-          if defined?(route.verb.source) then route.verb.source.to_s.delete('$'+'^') else route.verb end.downcase.to_sym 
+          if defined?(route.verb.source) then route.verb.source.to_s.delete('$'+'^') else route.verb end.downcase.to_sym
         end
 
         def path_route_nickname(path, route)
@@ -156,7 +156,8 @@ module Swagger
         end
 
         def generate_resource(path, apis, models, settings, root, config)
-          metadata = ApiDeclarationFileMetadata.new(root["apiVersion"], path, root["basePath"],
+          base_path = config[:exclude_api_version_in_path] ? config[:base_path]+'/' : root["basePath"]
+          metadata = ApiDeclarationFileMetadata.new(root["apiVersion"], path, base_path,
                                                    settings[:controller_base_path],
                                                    camelize_model_properties: config.fetch(:camelize_model_properties, true),
                                                    swagger_version: root["swaggerVersion"])


### PR DESCRIPTION
Added "exclude_api_version_in_path" feature for cases when API version is passed via headers.
Previously it wasn't possible to generate working json for such cases.

Added corresponding config option to the readme file