### PR TITLE
Add support for multiple base api controllers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The following table shows all the current configuration options and their defaul
 </tr>
 
 <tr>
-<td><b>base_api_controller</b></td>
-<td>The base controller class your project uses; it or its subclasses will be where you call swagger_controller and swagger_api.</td>
+<td><b>base_api_controller / base_api_controllers</b></td>
+<td>The base controller class your project uses; it or its subclasses will be where you call swagger_controller and swagger_api. An array of base controller classes may be provided.</td>
 <td>ActionController::Base</td>
 </tr>
 

--- a/lib/swagger/docs/config.rb
+++ b/lib/swagger/docs/config.rb
@@ -8,9 +8,15 @@ module Swagger
           @@base_api_controller || ActionController::Base
         end
 
+        def base_api_controllers
+          Array(base_api_controller)
+        end
+
         def base_api_controller=(controller)
           @@base_api_controller = controller
         end
+
+        alias_method :base_api_controllers=, :base_api_controller=
 
         def base_applications
           Array(base_application)
@@ -21,7 +27,9 @@ module Swagger
         end
 
         def register_apis(versions)
-          base_api_controller.send(:include, ImpotentMethods)
+          base_api_controllers.each do |controller|
+            controller.send(:include, ImpotentMethods)
+          end
           @versions = versions
         end
 

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -14,7 +14,10 @@ module Swagger
       class << self
 
         def set_real_methods
-          Config.base_api_controller.send(:include, Methods) # replace impotent methods with live ones
+          # replace impotent methods with live ones
+          Config.base_api_controllers.each do |controller|
+            controller.send(:include, Methods)
+          end
         end
 
         def write_docs(apis = nil)

--- a/spec/lib/swagger/docs/config_spec.rb
+++ b/spec/lib/swagger/docs/config_spec.rb
@@ -6,7 +6,7 @@ describe Swagger::Docs::Config do
 
   let(:test_controller) { Class.new }
 
-  before(:each) do 
+  before(:each) do
     stub_const('ActionController::Base', ApplicationController)
   end
 
@@ -19,7 +19,17 @@ describe Swagger::Docs::Config do
     it "allows assignment of another class" do
       subject.base_api_controller = test_controller
       expect(subject.base_api_controller).to eq(test_controller)
-    end 
+    end
+  end
+
+  describe "::base_api_controllers" do
+    it "returns an array with ActionController::Base by default" do
+      expect(subject.base_api_controllers).to eq([ActionController::Base])
+    end
+    it "allows assignment of multiple classes" do
+      subject.base_api_controllers = [test_controller, ActionController::Base]
+      expect(subject.base_api_controllers).to eq([test_controller, ActionController::Base])
+    end
   end
 
   describe "::base_application" do
@@ -34,6 +44,5 @@ describe Swagger::Docs::Config do
       expect(subject.base_applications).to eq [:app]
     end
   end
-
 
  end


### PR DESCRIPTION
An application I'm working on overrides Doorkeeper controllers and also uses rails-api.

This change allows me to specify an array of base api controllers.

``` ruby
Swagger::Docs::Config.base_api_controllers= [
  Doorkeeper::ApplicationMetalController,
  ActionController::API
]
```
