### PR TITLE
Enabled option to set 'items' inside swagger_api method

### DIFF
--- a/lib/swagger/docs/dsl.rb
+++ b/lib/swagger/docs/dsl.rb
@@ -29,6 +29,10 @@ module Swagger
         @type = type
       end
 
+      def items(items)
+        @items = items
+      end
+
       def consumes(mime_types)
         @consumes = mime_types
       end


### PR DESCRIPTION
This will enable us to use, inside swagger_api method:

type :array                
items({:"$ref" => "setup"})

This is intended to declare responses where the `root` JSON is itself an array.