### PR TITLE
Added property_list to SwaggerModelDSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ class Api::V1::UsersController < ApplicationController
     description "A Tag object."
     property :id, :integer, :required, "User Id"
     property :name, :string, :optional, "Name"
+    property_list :type, :string, :optional, "Tag Type", ["info", "warning", "error"]
   end
 
 end

--- a/lib/swagger/docs/dsl.rb
+++ b/lib/swagger/docs/dsl.rb
@@ -104,6 +104,12 @@ module Swagger
         }.merge!(hash)
         self.required << name if required == :required
       end
+      
+      # helper method to generate enums
+      def property_list(name, type, required, description = nil, allowed_values = [], hash = {})
+        hash.merge!({allowable_values: {value_type: "LIST", values: allowed_values}})
+        property(name, type, required, description, hash)
+      end
     end
   end
 end

--- a/spec/fixtures/controllers/sample_controller.rb
+++ b/spec/fixtures/controllers/sample_controller.rb
@@ -73,6 +73,7 @@ module Api
         description "A Tag object."
         property :id, :integer, :required, "User Id"
         property :name, :string, :optional, "Name", foo: "test"
+        property_list :type, :string, :optional, "Type", ["info", "warning", "error"]
       end
     end
   end

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -386,6 +386,18 @@ describe Swagger::Docs::Generator do
                 "id" => {
                   "type" => "integer",
                   "description" => "User Id",
+                },
+                "type" => {
+                  "type" => "string",
+                  "description" => "Type",
+                  "allowableValues" => {
+                    "valueType" => "LIST",
+                    "values" => [
+                      "info",
+                      "warning",
+                      "error"
+                    ]
+                  }
                 }
               }
             }


### PR DESCRIPTION
The `property_list` helper method conveniently allows defining a property which accepts an enum list. This is the swagger_model counterpart to `param_list`.