### PR TITLE
swagger_controller DSL can accept a resource_path which will be used over a generated path

### DIFF
--- a/lib/swagger/docs/api_declaration_file.rb
+++ b/lib/swagger/docs/api_declaration_file.rb
@@ -41,7 +41,7 @@ module Swagger
       end
 
       def resource_path
-        demod
+        metadata.overridden_resource_path || demod
       end
 
       def resource_file_path

--- a/lib/swagger/docs/api_declaration_file_metadata.rb
+++ b/lib/swagger/docs/api_declaration_file_metadata.rb
@@ -2,8 +2,9 @@ module Swagger
   module Docs
     class ApiDeclarationFileMetadata
       DEFAULT_SWAGGER_VERSION = "1.2"
+      DEFAULT_RESOURCE_PATH = nil
 
-      attr_reader :api_version, :path, :base_path, :controller_base_path, :swagger_version, :camelize_model_properties
+      attr_reader :api_version, :path, :base_path, :controller_base_path, :swagger_version, :camelize_model_properties, :overridden_resource_path
 
       def initialize(api_version, path, base_path, controller_base_path, options={})
         @api_version = api_version
@@ -12,6 +13,7 @@ module Swagger
         @controller_base_path = controller_base_path
         @swagger_version = options.fetch(:swagger_version, DEFAULT_SWAGGER_VERSION)
         @camelize_model_properties = options.fetch(:camelize_model_properties, true)
+        @overridden_resource_path = options.fetch(:resource_path, DEFAULT_RESOURCE_PATH)
       end
     end
   end

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -69,7 +69,7 @@ module Swagger
             ret = process_path(path, root, config, settings)
             results[ret[:action]] << ret
             if ret[:action] == :processed
-              resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config)
+              resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config, ret[:klass].swagger_config)
               debased_path = get_debased_path(ret[:path], settings[:controller_base_path])
               resource_api = {
                 path: "#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}",
@@ -158,11 +158,12 @@ module Swagger
           false
         end
 
-        def generate_resource(path, apis, models, settings, root, config)
+        def generate_resource(path, apis, models, settings, root, config, swagger_config)
           metadata = ApiDeclarationFileMetadata.new(root["apiVersion"], path, root["basePath"],
                                                    settings[:controller_base_path],
                                                    camelize_model_properties: config.fetch(:camelize_model_properties, true),
-                                                   swagger_version: root["swaggerVersion"])
+                                                   swagger_version: root["swaggerVersion"],
+                                                   resource_path: swagger_config[:resource_path])
           declaration = ApiDeclarationFile.new(metadata, apis, models)
           declaration.generate_resource
         end

--- a/lib/swagger/docs/impotent_methods.rb
+++ b/lib/swagger/docs/impotent_methods.rb
@@ -15,7 +15,7 @@ module Swagger
         def swagger_model(model_name, &block)
         end
 
-        def swagger_controller(controller, description)
+        def swagger_controller(controller, description, params={})
         end
       end
 

--- a/lib/swagger/docs/methods.rb
+++ b/lib/swagger/docs/methods.rb
@@ -10,6 +10,7 @@ module Swagger
         def swagger_controller(controller, description, params = {})
           swagger_config[:controller] = controller
           swagger_config[:description] = description
+          swagger_config[:resource_path] = params[:resource_path]
         end
 
         def swagger_actions

--- a/spec/fixtures/controllers/custom_resource_path_controller.rb
+++ b/spec/fixtures/controllers/custom_resource_path_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class SuperclassController < ApplicationController
+    end
+    class CustomResourcePathController < SuperclassController
+      swagger_controller :custom_resource_path, "User Management", resource_path: "testing"
+
+      swagger_api :index do
+        summary "Fetches all User items"
+        param :query, :page, :integer, :optional, "Page number"
+        param :path, :nested_id, :integer, :optional, "Team Id"
+        response :unauthorized
+        response :not_acceptable, "The request you made is not acceptable"
+        response :requested_range_not_satisfiable
+      end
+    end
+  end
+end

--- a/spec/fixtures/controllers/custom_resource_path_controller.rb
+++ b/spec/fixtures/controllers/custom_resource_path_controller.rb
@@ -3,7 +3,7 @@ module Api
     class SuperclassController < ApplicationController
     end
     class CustomResourcePathController < SuperclassController
-      swagger_controller :custom_resource_path, "User Management", resource_path: "testing"
+      swagger_controller :custom_resource_path, "User Management", resource_path: "resource/testing"
 
       swagger_api :index do
         summary "Fetches all User items"

--- a/spec/lib/swagger/docs/api_declaration_file_spec.rb
+++ b/spec/lib/swagger/docs/api_declaration_file_spec.rb
@@ -93,6 +93,22 @@ describe Swagger::Docs::ApiDeclarationFile do
     end
   end
 
+  describe "#resource_path" do
+    it "returns the debased controller path" do
+      metadata = double("metadata", overridden_resource_path: nil, controller_base_path: "/hello", path: "/hello/test-endpoint")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.resource_path).to eq("test_endpoint")
+    end
+
+    context "with an overridden_resource_path" do
+      it "returns the overriden resource path directly" do
+        metadata = double("metadata", overridden_resource_path: "testing-path", controller_base_path: "/hello", path: "/hello/test-endpoint")
+        declaration = described_class.new(metadata, apis, models)
+        expect(declaration.resource_path).to eq("testing-path")
+      end
+    end
+  end
+
   describe "#swagger_version" do
     it "returns metadata.swagger_version" do
       metadata = double("metadata", swagger_version: "1.2")

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -14,6 +14,7 @@ describe Swagger::Docs::Generator do
     stub_route(            "^GET$",    "index",   "api/v1/ignored", "/api/v1/ignored(.:format)"),
     stub_route(            "^GET$",    "index",   "api/v1/sample",  "/api/v1/sample(.:format)"),
     stub_string_verb_route("GET",      "index",   "api/v1/nested",  "/api/v1/nested/:nested_id/nested_sample(.:format)"),
+    stub_string_verb_route("GET",      "index",   "api/v1/custom_resource_path", "/api/v1/custom_resource_path/:custom_resource_path/custom_resource_path_sample(.:format)"),
     stub_route(            "^PATCH$",  "create",  "api/v1/sample",  "/api/v1/sample(.:format)"),
     stub_route(            "^PUT$",    "create",  "api/v1/sample",  "/api/v1/sample(.:format)"), # intentional duplicate of above route to ensure PATCH is used
     stub_route(            "^GET$",    "show",    "api/v1/sample",  "/api/v1/sample/:id(.:format)"),
@@ -28,6 +29,7 @@ describe Swagger::Docs::Generator do
   let(:file_resources) { tmp_dir + 'api-docs.json' }
   let(:file_resource) { tmp_dir + 'api/v1/sample.json' }
   let(:file_resource_nested) { tmp_dir + 'nested.json' }
+  let(:file_resource_custom_resource_path) { tmp_dir + 'custom_resource_path.json' }
 
   context "without controller base path" do
     let(:config) {
@@ -102,15 +104,19 @@ describe Swagger::Docs::Generator do
             "license" => "Apache 2.0",
             "licenseUrl" => "http://www.apache.org/licenses/LICENSE-2.0.html"
          }
-        } 
+        }
       }
     })}
     let(:file_resource) { tmp_dir + 'sample.json' }
+    let(:controllers) { [
+      "fixtures/controllers/sample_controller",
+      "fixtures/controllers/nested_controller",
+      "fixtures/controllers/custom_resource_path_controller"
+    ]}
     before(:each) do
       allow(Rails).to receive_message_chain(:application, :routes, :routes).and_return(routes)
       Swagger::Docs::Generator.set_real_methods
-      require "fixtures/controllers/sample_controller"
-      require "fixtures/controllers/nested_controller"
+      controllers.each{ |path| require path }
     end
 
     context "test suite initialization" do
@@ -129,7 +135,7 @@ describe Swagger::Docs::Generator do
         end
         it "generates using default config" do
           results = generate({})
-          expect(results[DEFAULT_VER][:processed].count).to eq 2
+          expect(results[DEFAULT_VER][:processed].count).to eq controllers.count
         end
       end
       before(:each) do
@@ -174,7 +180,7 @@ describe Swagger::Docs::Generator do
       end
       it "returns results hash" do
         results = generate(config)
-        expect(results[DEFAULT_VER][:processed].count).to eq 2
+        expect(results[DEFAULT_VER][:processed].count).to eq controllers.count
         expect(results[DEFAULT_VER][:skipped].count).to eq 1
       end
       it "writes pretty json files when set" do
@@ -196,7 +202,7 @@ describe Swagger::Docs::Generator do
           expect(response["basePath"]).to eq "http://api.no.where/api/v1/"
         end
         it "writes apis correctly" do
-          expect(response["apis"].count).to eq 2
+          expect(response["apis"].count).to eq controllers.count
         end
         it "writes api path correctly" do
           expect(response["apis"][0]["path"]).to eq "sample.{format}"
@@ -391,6 +397,15 @@ describe Swagger::Docs::Generator do
             }
             expect(models['Tag']).to eq expected_model
           end
+        end
+      end
+      context "custom resource_path resource file" do
+        let(:resource) { file_resource_custom_resource_path.read }
+        let(:response) { JSON.parse(resource) }
+        let(:apis) { response["apis"] }
+        # {"apiVersion":"1.0","swaggerVersion":"1.2","basePath":"/api/v1","resourcePath":"/sample"
+        it "writes resourcePath correctly" do
+          expect(response["resourcePath"]).to eq "testing"
         end
       end
     end

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -405,7 +405,7 @@ describe Swagger::Docs::Generator do
         let(:apis) { response["apis"] }
         # {"apiVersion":"1.0","swaggerVersion":"1.2","basePath":"/api/v1","resourcePath":"/sample"
         it "writes resourcePath correctly" do
-          expect(response["resourcePath"]).to eq "testing"
+          expect(response["resourcePath"]).to eq "resource/testing"
         end
       end
     end


### PR DESCRIPTION
This allows for custom paths to be defined which can then be fed into swagger-ui in a more user friendly way.