### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Swagger::Docs::Config.register_apis({
     # if you want to delete all .json files at each generation
     :clean_directory => false,
     # Ability to setup base controller for each api version. Api::V1::SomeController for example.
-    :parent_controller => Api::V1::SomeController
+    :parent_controller => Api::V1::SomeController,
     # add custom attributes to api-docs
     :attributes => {
       :info => {


### PR DESCRIPTION
small typo in the initializers/swagger_docs.rb file : the line for the parent_controller hash was missing a , before the the value :open_mouth: 