### PR TITLE
fixed  generate docs errors when just setting base_path

### DIFF
--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -51,8 +51,8 @@ module Swagger
           apis[DEFAULT_VER] = DEFAULT_CONFIG if apis.empty?
 
           apis.each do |api_version, config|
-            settings = get_settings(api_version, config)
             config.reverse_merge!(DEFAULT_CONFIG)
+            settings = get_settings(api_version, config)
             results[api_version] = generate_doc(api_version, settings, config)
             results[api_version][:settings] = settings
             results[api_version][:config] = config


### PR DESCRIPTION
When just setting base_path,

Swagger::Docs::Config.register_apis({
                                        '1.0' => {
                                            base_path: 'http://localhost:3000'
                                        }
                                    })

$: rails swagger:docs 
——————————————————
TypeError: no implicit conversion of nil into String
……/lib/swagger/docs/generator.rb:243:in `create_output_paths'
——————————————————
