### PR TITLE
fix generator for swagger_model when no property required

### DIFF
--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -209,9 +209,9 @@ module Swagger
           klass.swagger_models.each do |model_name, model|
             formatted_model = {
               id: model[:id],
-              required: model[:required],
               properties: model[:properties],
             }
+            formatted_model[:required] = model[:required] if model[:required]
             formatted_model[:description] = model[:description] if model[:description]
             models[model[:id]] = formatted_model
           end

--- a/spec/fixtures/controllers/sample_controller.rb
+++ b/spec/fixtures/controllers/sample_controller.rb
@@ -76,6 +76,11 @@ module Api
         property :name, :string, :optional, "Name", foo: "test"
         property_list :type, :string, :optional, "Type", ["info", "warning", "error"]
       end
+
+      swagger_model :OptionalTag do
+        description "A Tag object with no required property."
+        property :name, :string, :optional, "Name", foo: "test"
+      end
     end
   end
 end

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -435,7 +435,12 @@ describe Swagger::Docs::Generator do
             }
             expect(models['Tag']).to eq expected_model
           end
+
+          it "should not have required field when no property is required" do
+            expect(models['OptionalTag'].has_key?('required')).to eq false
+          end
         end
+
         context "custom resource_path resource file" do
           let(:resource) { file_resource_custom_resource_path.read }
           let(:response) { JSON.parse(resource) }


### PR DESCRIPTION
Before the fix, the generator is assigning null to `required` field,
which raises error
```
swagger-ui.js:2362 Uncaught TypeError: Swagger 2.0 does not support null types ([object Object]).  See https://github.com/swagger-api/swagger-spec/issues/229.
```

This fix will instead not to create a `required` field for the json, as to match the way how swagger_ui has done it, see https://github.com/swagger-api/swagger-ui/blob/master/test/specs/v1.2/petstore/store.json#L113