### PR TITLE
allow error handling to ignore a load error when guessing at the path

### DIFF
--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -61,10 +61,10 @@ module Swagger
         end
 
         def generate_doc(api_version, settings, config)
-          root = { 
-            "apiVersion" => api_version, 
-            "swaggerVersion" => "1.2", 
-            "basePath" => settings[:base_path], 
+          root = {
+            "apiVersion" => api_version,
+            "swaggerVersion" => "1.2",
+            "basePath" => settings[:base_path],
             :apis => [],
             :authorizations => settings[:authorizations]
           }
@@ -133,13 +133,17 @@ module Swagger
 
         def process_path(path, root, config, settings)
           return {action: :skipped, reason: :empty_path} if path.empty?
-          klass = Config.log_exception { "#{path.to_s.camelize}Controller".constantize } rescue nil
+          klass = begin
+            Config.log_exception { "#{path.to_s.camelize}Controller".constantize }
+          rescue LoadError, StandardError
+            nil
+          end
           return {action: :skipped, path: path, reason: :klass_not_present} if !klass
           return {action: :skipped, path: path, reason: :not_swagger_resource} if !klass.methods.include?(:swagger_config) or !klass.swagger_config[:controller]
           return {action: :skipped, path: path, reason: :not_kind_of_parent_controller} if config[:parent_controller] && !(klass < config[:parent_controller])
           apis, models, defined_nicknames = [], {}, []
           routes.select{|i| i.defaults[:controller] == path}.each do |route|
-            unless nickname_defined?(defined_nicknames, path, route) # only add once for each route once e.g. PATCH, PUT 
+            unless nickname_defined?(defined_nicknames, path, route) # only add once for each route once e.g. PATCH, PUT
               ret = get_route_path_apis(path, route, klass, settings, config)
               apis = apis + ret[:apis]
               models.merge!(ret[:models])


### PR DESCRIPTION
When the process_path code attempts to infer the class name from the file name, it can be incorrect when dealing with namespaced code that falls out of the norm. Catching this allows

```
class A::B
end
```

to fail gracefully, along with what was expected (example below)

```
module A
  class B
  end
end
```
