### PR TITLE
Feature/docroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Swagger::Docs::Config.register_apis({
     :api_file_path => "public/api/v1/",
     # the URL base path to your API
     :base_path => "http://api.somedomain.com",
+    # the path to the root of your api .json files
+    :api_document_root => "/api/v1",
     # if you want to delete all .json files at each generation
-    :clean_directory => false,
+    :clean_directory => true,
     # Ability to setup base controller for each api version. Api::V1::SomeController for example.
     :parent_controller => Api::V1::SomeController,
     # add custom attributes to api-docs
@@ -108,6 +110,12 @@ The following table shows all the current configuration options and their defaul
 <tr>
 <td><b>base_path</b></td>
 <td>The URI base path for your API - e.g. api.somedomain.com</td>
+<td>/</td>
+</tr>
+
+<tr>
+<td><b>api_document_root</b></td>
+<td>The URI path to your swagger .json files</td>
 <td>/</td>
 </tr>
 
@@ -277,7 +285,7 @@ class Api::V1::UserController < Api::V1::BaseController
     response :not_acceptable
     response :unprocessable_entity
   end
-  
+
   swagger_api :update do |api|
     summary "Update an existing User item"
     Api::V1::UserController::add_common_params(api)
@@ -384,7 +392,7 @@ end
 ```
 
 If you want swagger to find controllers in `Rails.application` and/or multiple
-engines you can override `base_application` to return an array. 
+engines you can override `base_application` to return an array.
 
 ```ruby
 class Swagger::Docs::Config

--- a/lib/swagger/docs/api_declaration_file.rb
+++ b/lib/swagger/docs/api_declaration_file.rb
@@ -36,8 +36,8 @@ module Swagger
         metadata.controller_base_path
       end
 
-      def swagger_document_root
-        metadata.swagger_document_root
+      def api_document_root
+        metadata.api_document_root
       end
 
       def camelize_model_properties

--- a/lib/swagger/docs/api_declaration_file.rb
+++ b/lib/swagger/docs/api_declaration_file.rb
@@ -36,6 +36,10 @@ module Swagger
         metadata.controller_base_path
       end
 
+      def swagger_document_root
+        metadata.swagger_document_root
+      end
+
       def camelize_model_properties
         metadata.camelize_model_properties
       end

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -78,7 +78,7 @@ module Swagger
               resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config, ret[:klass].swagger_config)
               debased_path = get_debased_path(ret[:path], settings[:controller_base_path])
               resource_api = {
-                path: [config[:swagger_document_root], "/#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}"].compact.join(''),
+                path: [config[:api_document_root], "/#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}"].compact.join(''),
                 description: ret[:klass].swagger_config[:description]
               }
               root[:apis] << resource_api

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -78,7 +78,7 @@ module Swagger
               resources << generate_resource(ret[:path], ret[:apis], ret[:models], settings, root, config, ret[:klass].swagger_config)
               debased_path = get_debased_path(ret[:path], settings[:controller_base_path])
               resource_api = {
-                path: "/#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}",
+                path: [config[:swagger_document_root], "/#{Config.transform_path(trim_leading_slash(debased_path), api_version)}.{format}"].compact.join(''),
                 description: ret[:klass].swagger_config[:description]
               }
               root[:apis] << resource_api

--- a/lib/swagger/docs/generator.rb
+++ b/lib/swagger/docs/generator.rb
@@ -61,10 +61,10 @@ module Swagger
         end
 
         def generate_doc(api_version, settings, config)
-          root = { 
-            "apiVersion" => api_version, 
-            "swaggerVersion" => "1.2", 
-            "basePath" => settings[:base_path], 
+          root = {
+            "apiVersion" => api_version,
+            "swaggerVersion" => "1.2",
+            "basePath" => settings[:base_path],
             :apis => [],
             :authorizations => settings[:authorizations]
           }
@@ -118,8 +118,10 @@ module Swagger
           str.gsub(/\A\/+/, '')
         end
 
+        # Only trim the trailing / if there are other characters
         def trim_trailing_slash(str)
           return str if !str
+          return str if str == '/'
           str.gsub(/\/+\z/, '')
         end
 
@@ -139,7 +141,7 @@ module Swagger
           return {action: :skipped, path: path, reason: :not_kind_of_parent_controller} if config[:parent_controller] && !(klass < config[:parent_controller])
           apis, models, defined_nicknames = [], {}, []
           routes.select{|i| i.defaults[:controller] == path}.each do |route|
-            unless nickname_defined?(defined_nicknames, path, route) # only add once for each route once e.g. PATCH, PUT 
+            unless nickname_defined?(defined_nicknames, path, route) # only add once for each route once e.g. PATCH, PUT
               ret = get_route_path_apis(path, route, klass, settings, config)
               apis = apis + ret[:apis]
               models.merge!(ret[:models])
@@ -219,7 +221,7 @@ module Swagger
         end
 
         def get_settings(api_version, config)
-          base_path = trim_trailing_slash(config[:base_path] || "")
+          base_path = trim_trailing_slash(config[:base_path] || "/")
           controller_base_path = trim_leading_slash(config[:controller_base_path] || "")
           base_path += "/#{controller_base_path}" unless controller_base_path.empty?
           api_file_path = config[:api_file_path]

--- a/spec/lib/swagger/docs/api_declaration_file_spec.rb
+++ b/spec/lib/swagger/docs/api_declaration_file_spec.rb
@@ -87,11 +87,11 @@ describe Swagger::Docs::ApiDeclarationFile do
       expect(declaration.controller_base_path).to eq(metadata.controller_base_path)
     end
   end
-  describe "#swagger_document_root" do
-    it "returns metadata.swagger_document_root" do
-      metadata = double("metadata", swagger_document_root: "/foobie")
+  describe "#api_document_root" do
+    it "returns metadata.api_document_root" do
+      metadata = double("metadata", api_document_root: "/foobie")
       declaration = described_class.new(metadata, apis, models)
-      expect(declaration.swagger_document_root).to eq(metadata.swagger_document_root)
+      expect(declaration.api_document_root).to eq(metadata.api_document_root)
     end
   end
   describe "#resource_path" do

--- a/spec/lib/swagger/docs/api_declaration_file_spec.rb
+++ b/spec/lib/swagger/docs/api_declaration_file_spec.rb
@@ -87,6 +87,13 @@ describe Swagger::Docs::ApiDeclarationFile do
       expect(declaration.controller_base_path).to eq(metadata.controller_base_path)
     end
   end
+  describe "#swagger_document_root" do
+    it "returns metadata.swagger_document_root" do
+      metadata = double("metadata", swagger_document_root: "/foobie")
+      declaration = described_class.new(metadata, apis, models)
+      expect(declaration.swagger_document_root).to eq(metadata.swagger_document_root)
+    end
+  end
   describe "#resource_path" do
     it "returns the debased controller path" do
       metadata = double("metadata", overridden_resource_path: nil, controller_base_path: "/hello", path: "/hello/test-endpoint")

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -32,10 +32,10 @@ describe Swagger::Docs::Generator do
   let(:file_resource_nested) { tmp_dir + 'nested.json' }
   let(:file_resource_custom_resource_path) { tmp_dir + 'custom_resource_path.json' }
 
-  let(:default_config) { 
+  let(:default_config) {
     {
-      :controller_base_path => "api/v1", 
-      :api_file_path => "#{tmp_dir}", 
+      :controller_base_path => "api/v1",
+      :api_file_path => "#{tmp_dir}",
       :base_path => "http://api.no.where/",
       :attributes => {
         :info => {
@@ -46,7 +46,7 @@ describe Swagger::Docs::Generator do
           "license" => "Apache 2.0",
           "licenseUrl" => "http://www.apache.org/licenses/LICENSE-2.0.html"
         }
-      } 
+      }
     }
   }
 
@@ -448,4 +448,29 @@ describe Swagger::Docs::Generator do
       end
     end
   end
+
+  context "base path tests" do
+    before(:each) do
+      allow(Rails).to receive_message_chain(:application, :routes, :routes).and_return(routes)
+      Swagger::Docs::Generator.set_real_methods
+      require "fixtures/controllers/sample_controller"
+    end
+
+    let(:resources) { file_resources.read }
+    let(:response) { JSON.parse(resources) }
+    let(:apis) { response["apis"] }
+
+    it "default basePath = '/'" do
+      config = {DEFAULT_VER => {:api_file_path => "#{tmp_dir}"}}#, :base_path => "http://api.no.where/"}}
+      generate(config)
+      expect(response['basePath']).to eq '/'
+    end
+
+    it "explicit '/' basePath = '/'" do
+      config = {DEFAULT_VER => {:api_file_path => "#{tmp_dir}", :base_path => "/"}}
+      generate(config)
+      expect(response['basePath']).to eq '/'
+    end
+  end
+
 end

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -474,7 +474,7 @@ describe Swagger::Docs::Generator do
     end
 
     it "swagger document root '/swagger' basePath = '/'" do
-      config = {DEFAULT_VER => {swagger_document_root: '/swagger', :api_file_path => "#{tmp_dir}", :base_path => "/"}}
+      config = {DEFAULT_VER => {api_document_root: '/swagger', :api_file_path => "#{tmp_dir}", :base_path => "/"}}
       generate(config)
       # expect(response).to eq '/swagger'
       expect(response['apis'].first['path']).to eq '/swagger/api/v1/sample.{format}'

--- a/spec/lib/swagger/docs/generator_spec.rb
+++ b/spec/lib/swagger/docs/generator_spec.rb
@@ -7,6 +7,7 @@ describe Swagger::Docs::Generator do
 
   before(:each) do
     FileUtils.rm_rf(tmp_dir)
+    FileUtils.mkdir(tmp_dir)
     stub_const('ActionController::Base', ApplicationController)
   end
 
@@ -470,6 +471,13 @@ describe Swagger::Docs::Generator do
       config = {DEFAULT_VER => {:api_file_path => "#{tmp_dir}", :base_path => "/"}}
       generate(config)
       expect(response['basePath']).to eq '/'
+    end
+
+    it "swagger document root '/swagger' basePath = '/'" do
+      config = {DEFAULT_VER => {swagger_document_root: '/swagger', :api_file_path => "#{tmp_dir}", :base_path => "/"}}
+      generate(config)
+      # expect(response).to eq '/swagger'
+      expect(response['apis'].first['path']).to eq '/swagger/api/v1/sample.{format}'
     end
   end
 


### PR DESCRIPTION
Add support for .json document root.  So if you put your .json files in 
public/api_files
you can set
`api_document_root: '/api_files'
`
and the paths will line up.